### PR TITLE
Add focus management for text input on keyboard shortcut

### DIFF
--- a/ClaudeCodeUI/UI/ChatInputView.swift
+++ b/ClaudeCodeUI/UI/ChatInputView.swift
@@ -23,6 +23,7 @@ struct ChatInputView: View {
   @FocusState private var isFocused: Bool
   let placeholder: String
   @State private var shouldSubmit = false
+  @Binding var triggerFocus: Bool
   @State private var showingSessionsList = false
   @State private var showingProjectPathAlert = false
   @State private var showingSettings = false
@@ -52,7 +53,8 @@ struct ChatInputView: View {
     contextManager: ContextManager,
     xcodeObservationViewModel: XcodeObservationViewModel,
     permissionsService: PermissionsService,
-    placeholder: String = "Type a message...")
+    placeholder: String = "Type a message...",
+    triggerFocus: Binding<Bool> = .constant(false))
   {
     _text = text
     _viewModel = chatViewModel
@@ -60,6 +62,7 @@ struct ChatInputView: View {
     self.xcodeObservationViewModel = xcodeObservationViewModel
     self.permissionsService = permissionsService
     self.placeholder = placeholder
+    _triggerFocus = triggerFocus
   }
   // MARK: - Body
   var body: some View {
@@ -277,6 +280,12 @@ extension ChatInputView {
         .padding(textAreaEdgeInsets)
         .onAppear {
           isFocused = true
+        }
+        .onChange(of: triggerFocus) { _, shouldFocus in
+          if shouldFocus {
+            isFocused = true
+            triggerFocus = false
+          }
         }
         .onChange(of: text) { oldValue, newValue in
           // Simple check to avoid freezing

--- a/ClaudeCodeUI/UI/ChatScreen.swift
+++ b/ClaudeCodeUI/UI/ChatScreen.swift
@@ -33,6 +33,7 @@ struct ChatScreen: View {
   @State var hasShownAutoDetectionAlert = false
   @State var detectedProjectPath: String?
   @State var showingPathDetectionAlert = false
+  @State private var triggerTextEditorFocus = false
   
   var body: some View {
     VStack {
@@ -85,7 +86,8 @@ struct ChatScreen: View {
         contextManager: contextManager,
         xcodeObservationViewModel: xcodeObservationViewModel,
         permissionsService: permissionsService,
-        placeholder: "Type a message...")
+        placeholder: "Type a message...",
+        triggerFocus: $triggerTextEditorFocus)
     }
     .navigationTitle("Claude Code Chat")
     .toolbar {
@@ -129,6 +131,13 @@ struct ChatScreen: View {
           // No Xcode selection, use clipboard text
           contextManager.addCapturedText(newValue)
         }
+      }
+    }
+    .onChange(of: keyboardManager.shouldFocusTextEditor) { _, shouldFocus in
+      if shouldFocus {
+        triggerTextEditorFocus = true
+        // Reset the flag after using it
+        keyboardManager.shouldFocusTextEditor = false
       }
     }
   }

--- a/ClaudeCodeUI/ViewModels/KeyboardShortcutManager.swift
+++ b/ClaudeCodeUI/ViewModels/KeyboardShortcutManager.swift
@@ -13,6 +13,7 @@ import AppKit
 class KeyboardShortcutManager {
   var capturedText: String = ""
   var showCaptureAnimation = false
+  var shouldFocusTextEditor = false
   
   init() {
     setupShortcuts()
@@ -51,6 +52,20 @@ class KeyboardShortcutManager {
         self?.capturedText = selectedText
         self?.showCaptureAnimation = true
         
+        // Activate the app more reliably
+        NSRunningApplication.current.activate()
+        
+        // Ensure window comes to front
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+          // Find and activate the key window
+          if let keyWindow = NSApplication.shared.keyWindow ?? NSApplication.shared.windows.first {
+            keyWindow.makeKeyAndOrderFront(nil)
+          }
+        }
+        
+        // Trigger focus on text editor
+        self?.shouldFocusTextEditor = true
+        
         // Hide animation after 2 seconds
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
           self?.showCaptureAnimation = false
@@ -70,3 +85,4 @@ class KeyboardShortcutManager {
 extension KeyboardShortcuts.Name {
   static let captureWithI = Self("captureWithI", default: .init(.i, modifiers: [.command]))
 }
+


### PR DESCRIPTION
- Add triggerFocus binding to ChatInputView for programmatic focus control
- Connect keyboard shortcut to automatically focus text input field
- Improve app activation reliability when capturing text
- Ensure window comes to front before setting focus

