### PR TITLE
Add Terminal launch capability and improve session ID tracking

### DIFF
--- a/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
@@ -87,6 +87,13 @@ public final class ChatViewModel {
     sessionManager.currentSessionId
   }
   
+  /// Active session ID (includes pending session during streaming)
+  /// This returns the session ID that Claude is actively using, which may be
+  /// different from currentSessionId during streaming operations
+  var activeSessionId: String? {
+    streamProcessor.activeSessionId
+  }
+  
   /// Loading state
   public private(set) var isLoading: Bool = false
   

--- a/Sources/ClaudeCodeCore/ViewModels/StreamProcessor.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/StreamProcessor.swift
@@ -27,6 +27,12 @@ final class StreamProcessor {
   // Track pending session ID during streaming (only commit on success)
   private var pendingSessionId: String?
   
+  /// Gets the currently active session ID (pending or current)
+  /// Returns the pending session ID if streaming is in progress, otherwise the current session ID
+  var activeSessionId: String? {
+    pendingSessionId ?? sessionManager.currentSessionId
+  }
+  
   // Stream state holder
   private class StreamState {
     var contentBuffer = ""


### PR DESCRIPTION
## Summary
- Replaces "Copy Session ID" button with "Continue in Terminal" functionality
- Adds ability to launch Terminal with Claude resume command directly from the UI
- Improves session ID tracking to handle pending sessions during streaming

## Changes
1. **ChatScreen.swift**: 
   - Changed copy button to terminal launch button
   - Added `launchTerminalWithSession()` method to open Terminal with resume command
   - Added `findClaudeExecutable()` helper to locate Claude CLI

2. **ChatViewModel.swift**: 
   - Added `activeSessionId` property that returns pending or current session ID

3. **StreamProcessor.swift**: 
   - Added `activeSessionId` property to track session during streaming operations

## Test Plan
- [ ] Verify Terminal button appears when session is active
- [ ] Test launching Terminal with active session
- [ ] Confirm correct resume command is executed in Terminal
- [ ] Test with different Claude installation paths (npm, standalone)
- [ ] Verify session ID tracking during streaming operations

🤖 Generated with [Claude Code](https://claude.ai/code)