### PR TITLE
Rename showRiskLabel to showRiskData and control low-risk toggle visi…

### DIFF
--- a/ClaudeCodeUI/App.swift
+++ b/ClaudeCodeUI/App.swift
@@ -29,7 +29,7 @@ struct ClaudeCodeUIAppWrapper: App {
           uiConfiguration: UIConfiguration(
             appName: "Claude Code UI",
             showSettingsInNavBar: true,
-            showRiskLabel: false)
+            showRiskData: false)
         )
         .environment(globalPreferences)
       } else {

--- a/Sources/ClaudeCodeCore/Models/ClaudeCodeAppConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/ClaudeCodeAppConfiguration.swift
@@ -53,14 +53,14 @@ public struct ClaudeCodeAppConfiguration {
   public init(
     appName: String,
     showSettingsInNavBar: Bool,
-    showRiskLabel: Bool = true
+    showRiskData: Bool = true
   ) {
     self.init(
       claudeCodeConfiguration: .default,
       uiConfiguration: UIConfiguration(
         appName: appName,
         showSettingsInNavBar: showSettingsInNavBar,
-        showRiskLabel: showRiskLabel
+        showRiskData: showRiskData
       )
     )
   }
@@ -83,7 +83,7 @@ public struct ClaudeCodeAppConfiguration {
     appName: String,
     workingDirectory: String? = nil,
     showSettingsInNavBar: Bool,
-    showRiskLabel: Bool = true
+    showRiskData: Bool = true
   ) {
     var config = ClaudeCodeConfiguration.default
     config.workingDirectory = workingDirectory
@@ -92,7 +92,7 @@ public struct ClaudeCodeAppConfiguration {
       uiConfiguration: UIConfiguration(
         appName: appName,
         showSettingsInNavBar: showSettingsInNavBar,
-        showRiskLabel: showRiskLabel
+        showRiskData: showRiskData
       )
     )
   }

--- a/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
@@ -15,8 +15,8 @@ public struct UIConfiguration {
   /// Whether to show the settings button in the navigation bar
   public let showSettingsInNavBar: Bool
   
-  /// Whether to show the risk label in approval toasts
-  public let showRiskLabel: Bool
+  /// Whether to show risk-related data (risk labels and low-risk auto-approve option)
+  public let showRiskData: Bool
   
   /// Whether to show the token count in the loading indicator
   public let showTokenCount: Bool
@@ -26,7 +26,7 @@ public struct UIConfiguration {
     UIConfiguration(
       appName: "Claude Code UI",
       showSettingsInNavBar: true,
-      showRiskLabel: true,
+      showRiskData: true,
       showTokenCount: true
     )
   }
@@ -36,7 +36,7 @@ public struct UIConfiguration {
     UIConfiguration(
       appName: "Claude Code",
       showSettingsInNavBar: false,
-      showRiskLabel: true,
+      showRiskData: true,
       showTokenCount: true
     )
   }
@@ -45,12 +45,12 @@ public struct UIConfiguration {
   public init(
     appName: String,
     showSettingsInNavBar: Bool = false,
-    showRiskLabel: Bool = true,
+    showRiskData: Bool = true,
     showTokenCount: Bool = true
   ) {
     self.appName = appName
     self.showSettingsInNavBar = showSettingsInNavBar
-    self.showRiskLabel = showRiskLabel
+    self.showRiskData = showRiskData
     self.showTokenCount = showTokenCount
   }
 }

--- a/Sources/ClaudeCodeCore/UI/ChatScreen.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatScreen.swift
@@ -212,7 +212,7 @@ public struct ChatScreen: View {
         if let request = permissionService.currentToastRequest {
         ApprovalToast(
           request: request,
-          showRiskLabel: uiConfiguration.showRiskLabel,
+          showRiskData: uiConfiguration.showRiskData,
           queueCount: permissionService.approvalQueue.count,
           onApprove: {
             permissionService.approveCurrentToast()
@@ -308,7 +308,7 @@ public struct ChatScreen: View {
         permissionsService: permissionsService
       )
     case .global:
-      GlobalSettingsView()
+      GlobalSettingsView(uiConfiguration: uiConfiguration)
     }
   }
   

--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 
 struct GlobalSettingsView: View {
+  let uiConfiguration: UIConfiguration
+  
+  init(uiConfiguration: UIConfiguration = .default) {
+    self.uiConfiguration = uiConfiguration
+  }
+  
   // MARK: - Constants
   private enum Layout {
     static let windowWidth: CGFloat = 700
@@ -114,7 +120,8 @@ struct GlobalSettingsView: View {
     MCPConfigurationView(
       isPresented: $showingMCPConfig,
       mcpConfigStorage: globalPreferences,
-      globalPreferences: globalPreferences
+      globalPreferences: globalPreferences,
+      uiConfiguration: uiConfiguration
     )
   }
   

--- a/Sources/ClaudeCodeCore/UI/MCPConfigurationView.swift
+++ b/Sources/ClaudeCodeCore/UI/MCPConfigurationView.swift
@@ -13,6 +13,7 @@ struct MCPConfigurationView: View {
   @Binding var isPresented: Bool
   let mcpConfigStorage: MCPConfigStorage
   let globalPreferences: GlobalPreferencesStorage?
+  let uiConfiguration: UIConfiguration
   @State private var configManager = MCPConfigurationManager()
   // Removed selectedServer and showingAddServer as editing is now done via JSON editor
   @State private var showingJSONEditor = false
@@ -182,12 +183,14 @@ struct MCPConfigurationView: View {
             ))
             .help("Automatically approve all tool requests without showing permission prompts")
             
-            Toggle("Auto-approve low-risk operations", isOn: Binding(
-              get: { preferences.autoApproveLowRisk },
-              set: { preferences.autoApproveLowRisk = $0 }
-            ))
-            .help("Automatically approve operations classified as low-risk (e.g., reading files)")
-            .disabled(preferences.autoApproveToolCalls) // Disable if auto-approve all is on
+            if uiConfiguration.showRiskData {
+              Toggle("Auto-approve low-risk operations", isOn: Binding(
+                get: { preferences.autoApproveLowRisk },
+                set: { preferences.autoApproveLowRisk = $0 }
+              ))
+              .help("Automatically approve operations classified as low-risk (e.g., reading files)")
+              .disabled(preferences.autoApproveToolCalls) // Disable if auto-approve all is on
+            }
           }
           
           Divider()
@@ -411,6 +414,7 @@ struct QuickAddServerRow: View {
   return MCPConfigurationView(
     isPresented: .constant(true),
     mcpConfigStorage: PreviewMCPStorage(),
-    globalPreferences: nil
+    globalPreferences: nil,
+    uiConfiguration: .default
   )
 }

--- a/Sources/CustomPermissionService/ApprovalToast.swift
+++ b/Sources/CustomPermissionService/ApprovalToast.swift
@@ -10,13 +10,13 @@ public struct ApprovalToast: View {
 
   public init(
     request: ApprovalRequest,
-    showRiskLabel: Bool = true,
+    showRiskData: Bool = true,
     queueCount: Int = 0,
     onApprove: @escaping () -> Void,
     onDeny: @escaping () -> Void
   ) {
     self.request = request
-    self.showRiskLabel = showRiskLabel
+    self.showRiskData = showRiskData
     self.queueCount = queueCount
     self.onApprove = onApprove
     self.onDeny = onDeny
@@ -52,7 +52,7 @@ public struct ApprovalToast: View {
   // MARK: Internal
 
   let request: ApprovalRequest
-  let showRiskLabel: Bool
+  let showRiskData: Bool
   let queueCount: Int
   let onApprove: () -> Void
   let onDeny: () -> Void
@@ -92,7 +92,7 @@ public struct ApprovalToast: View {
 
         Spacer()
 
-        if showRiskLabel {
+        if showRiskData {
           Text(request.context?.riskLevel.displayName ?? "Unknown")
             .font(.system(size: 11))
             .padding(.horizontal, 6)


### PR DESCRIPTION
…bility

- Renamed showRiskLabel to showRiskData throughout the codebase for better clarity
- Updated MCPConfigurationView to conditionally show "Auto-approve low-risk operations" toggle based on showRiskData config
- Added UIConfiguration parameter to MCPConfigurationView and GlobalSettingsView
- When showRiskData is false, the low-risk operations toggle is hidden from Custom Permission Settings

🤖 Generated with [Claude Code](https://claude.ai/code)