### PR TITLE
Switch ClaudeCodeSDK to semantic versioning

### DIFF
--- a/ClaudeCodeUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ClaudeCodeUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jamesrochabrun/ClaudeCodeSDK",
       "state" : {
-        "branch" : "main",
-        "revision" : "0c287d2d9ecd0b6c56c0e7beffac86aa44c4d50b"
+        "revision" : "0c287d2d9ecd0b6c56c0e7beffac86aa44c4d50b",
+        "version" : "1.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         // External dependencies
-        .package(url: "https://github.com/jamesrochabrun/ClaudeCodeSDK", branch: "main"),
+        .package(url: "https://github.com/jamesrochabrun/ClaudeCodeSDK", from: "1.1.2"),
         .package(url: "https://github.com/jamesrochabrun/SwiftAnthropic", from: "2.1.7"),
         .package(url: "https://github.com/sindresorhus/KeyboardShortcuts", from: "2.3.0"),
         .package(url: "https://github.com/jamesrochabrun/Down", branch: "fix/external-cmark-dependency"),


### PR DESCRIPTION
## Summary
- Switched ClaudeCodeSDK dependency from tracking `main` branch to using semantic versioning (`from: "1.1.2"`)
- Updated Package.resolved to reflect the version-based dependency

## Why this change?
Using semantic versioning instead of branch tracking provides:
- **Stability**: Reproducible builds with consistent dependency versions
- **Predictability**: No unexpected breaking changes from upstream updates
- **Production readiness**: Following best practices for dependency management
- **Better collaboration**: All developers get the same exact dependency version

## Technical details
- Changed from `branch: "main"` to `from: "1.1.2"` in Package.swift
- The actual code revision remains the same (`0c287d2d9ecd0b6c56c0e7beffac86aa44c4d50b`)
- This is a safe change with no functional impact

🤖 Generated with [Claude Code](https://claude.ai/code)