### PR TITLE
fix: update upload-artifact action from v3 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Upload DMG artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ClaudeCodeUI-${{ env.VERSION }}
         path: build/dmg/ClaudeCodeUI.dmg


### PR DESCRIPTION
GitHub deprecated v3 of the upload-artifact action in April 2024. This commit updates to v4 to resolve CI failures.

🤖 Generated with [Claude Code](https://claude.ai/code)