### PR TITLE
Fix: Clear currentSessionId when deleting the active session

### DIFF
--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -259,10 +259,23 @@ public struct ClaudeCodeContainer: View {
   
   private func deleteSession(_ session: StoredSession) async {
     do {
+      // Check if we're deleting the current session
+      if session.id == currentSessionId {
+        await MainActor.run {
+          currentSessionId = nil
+        }
+        // Also clear the chat interface if needed
+        if let viewModel = chatViewModel {
+          await MainActor.run {
+            viewModel.clearConversation()
+          }
+        }
+      }
+
       try await sessionManager.deleteSession(sessionId: session.id)
-      
+
       await loadAvailableSessions()
-      
+
       await MainActor.run {
         sessionToDelete = nil
       }


### PR DESCRIPTION
## Summary
- Fixed an issue where deleting the current session would still show it in the UI
- The deleted session would reappear until app restart

## Problem
When deleting the currently active session, the session would be removed from the database but still appear in the sessions list. This happened because `currentSessionId` wasn't being cleared, causing `loadAvailableSessions()` to recreate it as a placeholder session.

## Solution
Modified the `deleteSession` function in `ClaudeCodeContainer.swift` to:
1. Check if the session being deleted is the current session
2. Clear `currentSessionId` if it matches
3. Clear the chat interface to reset the UI state

## Test Plan
1. Open the app and create/select a session
2. Add some messages to make it the current active session
3. Delete the current session from the sessions list
4. ✅ The session should be completely removed from the UI
5. ✅ The chat interface should be cleared
6. ✅ The session should not reappear in the list

🤖 Generated with [Claude Code](https://claude.ai/code)