### PR TITLE
Fix Claude command override not being applied correctly

### DIFF
--- a/Sources/ClaudeCodeCore/Data/GlobalPreferencesStorage.swift
+++ b/Sources/ClaudeCodeCore/Data/GlobalPreferencesStorage.swift
@@ -22,6 +22,7 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
     static let allowedTools = "global.allowedTools"
     static let mcpConfigPath = "global.mcpConfigPath"
     static let defaultWorkingDirectory = "global.defaultWorkingDirectory"
+    static let claudeCommand = "global.claudeCommand"
 
     // Custom permission settings
     static let autoApproveLowRisk = "global.autoApproveLowRisk"
@@ -66,6 +67,12 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
   public var defaultWorkingDirectory: String {
     didSet {
       userDefaults.set(defaultWorkingDirectory, forKey: Keys.defaultWorkingDirectory)
+    }
+  }
+
+  public var claudeCommand: String {
+    didSet {
+      userDefaults.set(claudeCommand, forKey: Keys.claudeCommand)
     }
   }
 
@@ -142,7 +149,10 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
 
     // Load default working directory or use empty string
     self.defaultWorkingDirectory = userDefaults.string(forKey: Keys.defaultWorkingDirectory) ?? ""
-    
+
+    // Load Claude command or use default
+    self.claudeCommand = userDefaults.string(forKey: Keys.claudeCommand) ?? "claude"
+
     // Load custom permission settings or use defaults
     self.autoApproveLowRisk = userDefaults.object(forKey: Keys.autoApproveLowRisk) as? Bool ?? false
     self.showDetailedPermissionInfo = userDefaults.object(forKey: Keys.showDetailedPermissionInfo) as? Bool ?? true
@@ -173,7 +183,8 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
       .appendingPathComponent(".config/claude/mcp-config.json")
       .path
     defaultWorkingDirectory = ""
-    
+    claudeCommand = "claude"
+
     // Reset permission settings
     autoApproveLowRisk = false
     showDetailedPermissionInfo = true

--- a/Sources/ClaudeCodeCore/UI/ChatScreen.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatScreen.swift
@@ -307,7 +307,8 @@ public struct ChatScreen: View {
       GlobalSettingsView(
         uiConfiguration: uiConfiguration,
         xcodeObservationViewModel: xcodeObservationViewModel,
-        permissionsService: permissionsService
+        permissionsService: permissionsService,
+        chatViewModel: viewModel
       )
     }
   }

--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -13,15 +13,18 @@ struct GlobalSettingsView: View {
   let uiConfiguration: UIConfiguration
   let xcodeObservationViewModel: XcodeObservationViewModel?
   let permissionsService: PermissionsService?
+  let chatViewModel: ChatViewModel?
 
   init(
     uiConfiguration: UIConfiguration = .default,
     xcodeObservationViewModel: XcodeObservationViewModel? = nil,
-    permissionsService: PermissionsService? = nil
+    permissionsService: PermissionsService? = nil,
+    chatViewModel: ChatViewModel? = nil
   ) {
     self.uiConfiguration = uiConfiguration
     self.xcodeObservationViewModel = xcodeObservationViewModel
     self.permissionsService = permissionsService
+    self.chatViewModel = chatViewModel
   }
   
   // MARK: - Constants
@@ -70,6 +73,10 @@ struct GlobalSettingsView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button("Done") {
+          // Update the Claude command in the view model if it exists
+          if let viewModel = chatViewModel {
+            viewModel.updateClaudeCommand(from: globalPreferences)
+          }
           dismiss()
         }
       }
@@ -212,6 +219,7 @@ struct GlobalSettingsView: View {
   private var claudeCodeConfigurationSection: some View {
     Section("ClaudeCode Configuration") {
       defaultWorkingDirectoryRow
+      claudeCommandRow
       maxTurnsRow
       if uiConfiguration.showSystemPromptFields {
         systemPromptRow
@@ -293,6 +301,29 @@ struct GlobalSettingsView: View {
         }
       }
       Text("New sessions will use this directory by default")
+        .font(.caption)
+        .foregroundColor(.secondary)
+    }
+  }
+
+  @ViewBuilder
+  private var claudeCommandRow: some View {
+    @Bindable var preferences = globalPreferences
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Claude Command")
+      HStack {
+        TextField("Command", text: $preferences.claudeCommand)
+          .textFieldStyle(.roundedBorder)
+          .font(.system(.body, design: .monospaced))
+
+        if preferences.claudeCommand != "claude" {
+          Button("Reset") {
+            preferences.claudeCommand = "claude"
+          }
+          .foregroundColor(.orange)
+        }
+      }
+      Text("The command to execute Claude Code (default: 'claude')")
         .font(.caption)
         .foregroundColor(.secondary)
     }

--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -90,7 +90,9 @@ public struct ClaudeCodeContainer: View {
       customSessionStorage: customStorage,
     )
 
-    let config = claudeCodeConfiguration
+    var config = claudeCodeConfiguration
+    // Override the command with the one from global preferences
+    config.command = globalPrefs.claudeCommand
 
     let claudeClient = ClaudeCodeClient(configuration: config)
     

--- a/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
@@ -178,6 +178,11 @@ public final class ChatViewModel {
   public func refreshProjectPath() {
     projectPath = settingsStorage.projectPath
   }
+
+  /// Updates the Claude command when global preferences change
+  public func updateClaudeCommand(from globalPreferences: GlobalPreferencesStorage) {
+    claudeClient.configuration.command = globalPreferences.claudeCommand
+  }
   
   // MARK: - Public Methods
   


### PR DESCRIPTION
## Summary
- Fixed issue where custom Claude commands weren't being applied when sending messages
- Fixed issue where resetting preferences didn't update the active command until app restart

## Problem
When users configured a custom command in global preferences (instead of the default "claude"), the messages were still being sent using "claude" as the command. Additionally, when users reset preferences and clicked "Done", the old command was still being used.

## Solution
1. Added `claudeCommand` property to `GlobalPreferencesStorage` with proper persistence to UserDefaults
2. Override the command from global preferences when creating `ClaudeCodeClient` in `ClaudeCodeContainer`
3. Added `updateClaudeCommand` method to `ChatViewModel` to update the command when preferences change
4. Updated `GlobalSettingsView` to call `updateClaudeCommand` when Done is pressed
5. Pass `ChatViewModel` to `GlobalSettingsView` from `ChatScreen`

## Test Plan
- [x] Set a custom command in Global Settings
- [x] Send a message and verify it uses the custom command
- [x] Reset preferences and click Done
- [x] Send another message and verify it uses the default "claude" command
- [x] Restart app and verify custom commands persist

🤖 Generated with [Claude Code](https://claude.ai/code)