### PR TITLE
Add reset button for MCP configuration path

### DIFF
--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -412,10 +412,12 @@ struct GlobalSettingsView: View {
   }
   
   private var mcpConfigurationStatus: some View {
-    Text("~/.config/claude/mcp-config.json")
+    Text(globalPreferences.mcpConfigPath)
       .font(.system(.body, design: .monospaced))
       .foregroundColor(.secondary)
       .frame(maxWidth: .infinity, alignment: .leading)
+      .lineLimit(1)
+      .truncationMode(.middle)
   }
   
   private func promptTextEditor(text: Binding<String>) -> some View {


### PR DESCRIPTION
## Summary
- Added reset button to easily revert MCP configuration path back to default
- Enhanced UI with visual indicators when using custom configuration paths
- Improved JSON editor change detection to prevent unnecessary "unsaved changes" alerts

## Changes
- **Reset functionality**: Added reset button that appears only when using a custom MCP config path
- **Visual feedback**: Shows orange color and "Custom" label with icon when path is customized  
- **Fixed display bug**: GlobalSettingsView now shows actual preference path instead of hardcoded value
- **Smart change detection**: JSON editor now compares semantic content to detect real changes, ignoring formatting differences
- **Better UX**: "Unsaved Changes" alert only appears when JSON content actually differs

## Test Plan
- [x] Test reset button appears only when using custom path
- [x] Verify reset button correctly reverts to default path
- [x] Check visual indicators display correctly for custom paths
- [x] Confirm JSON editor doesn't show alert when no changes made
- [x] Test JSON editor properly detects real content changes
- [x] Verify path display updates correctly in preferences view

🤖 Generated with [Claude Code](https://claude.ai/code)