### PR TITLE
Release v1.3.7

### DIFF
--- a/ClaudeCodeUI/Info.plist
+++ b/ClaudeCodeUI/Info.plist
@@ -17,7 +17,7 @@
   <key>CFBundlePackageType</key>
   <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
   <key>CFBundleShortVersionString</key>
-  <string>1.0.0</string>
+  <string>1.3.7</string>
   <key>CFBundleVersion</key>
   <string>1</string>
   <key>LSMinimumSystemVersion</key>

--- a/Scripts/export_options_dmg.plist
+++ b/Scripts/export_options_dmg.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>mac-application</string>
+  <key>teamID</key>
+  <string>CQ45U4X9K3</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Update app version to 1.3.7
- Add DMG export options for macOS distribution
- Prepare release build with installer

## Changes
- Updated `CFBundleShortVersionString` in Info.plist to 1.3.7
- Added export options plist for DMG creation
- Built and verified DMG installer

## Release Assets
- DMG installer ready for distribution (3.0MB)
- All security checks passed

## Test Plan
- [x] Version updated correctly
- [x] DMG builds successfully
- [x] DMG verification passes
- [x] No sensitive data exposed

🤖 Generated with [Claude Code](https://claude.ai/code)