### PR TITLE
Add user message event callback for logging

### DIFF
--- a/Examples/UserMessageLoggingExample.swift
+++ b/Examples/UserMessageLoggingExample.swift
@@ -1,0 +1,141 @@
+//
+//  UserMessageLoggingExample.swift
+//  ClaudeCodeUI
+//
+//  Example showing how to use the onUserMessageSent callback
+//  to log user messages in your application.
+//
+
+import SwiftUI
+import ClaudeCodeCore
+import ClaudeCodeSDK
+
+struct UserMessageLoggingExampleApp: App {
+
+  var config: ClaudeCodeConfiguration {
+    ClaudeCodeConfiguration.default
+  }
+
+  var body: some Scene {
+    WindowGroup {
+      ClaudeCodeContainer(
+        claudeCodeConfiguration: config,
+        uiConfiguration: UIConfiguration(
+          appName: "Claude Code with Logging",
+          showSettingsInNavBar: true
+        ),
+        onUserMessageSent: { message, codeSelections, attachments in
+          // Log user message to your analytics system
+          logUserMessage(message, codeSelections: codeSelections, attachments: attachments)
+        }
+      )
+    }
+  }
+
+  private func logUserMessage(_ message: String, codeSelections: [TextSelection]?, attachments: [FileAttachment]?) {
+    // Example: Log to console
+    print("📝 User Message Sent:")
+    print("   Message: \(message)")
+
+    if let codeSelections = codeSelections, !codeSelections.isEmpty {
+      print("   Code Selections: \(codeSelections.count) files")
+      for selection in codeSelections {
+        print("     - \(selection.filePath)")
+      }
+    }
+
+    if let attachments = attachments, !attachments.isEmpty {
+      print("   Attachments: \(attachments.count) files")
+      for attachment in attachments {
+        print("     - \(attachment.fileName)")
+      }
+    }
+
+    // Example: Send to analytics service
+    // AnalyticsService.shared.track(.userMessageSent, properties: [
+    //   "message_length": message.count,
+    //   "has_code_selections": codeSelections != nil,
+    //   "has_attachments": attachments != nil,
+    //   "attachment_count": attachments?.count ?? 0
+    // ])
+
+    // Example: Store in local database for usage metrics
+    // UsageMetrics.shared.recordUserMessage(
+    //   message: message,
+    //   timestamp: Date(),
+    //   metadata: [
+    //     "code_selections": codeSelections?.count ?? 0,
+    //     "attachments": attachments?.count ?? 0
+    //   ]
+    // )
+  }
+}
+
+// MARK: - Advanced Example with Custom Logging Service
+
+class MessageLoggingService {
+  static let shared = MessageLoggingService()
+
+  private init() {}
+
+  func logUserMessage(_ message: String, codeSelections: [TextSelection]?, attachments: [FileAttachment]?) {
+    // Create a structured log entry
+    let logEntry = UserMessageLogEntry(
+      timestamp: Date(),
+      message: message,
+      codeSelectionCount: codeSelections?.count ?? 0,
+      attachmentCount: attachments?.count ?? 0,
+      hasCodeContext: codeSelections != nil && !codeSelections.isEmpty,
+      hasAttachments: attachments != nil && !attachments.isEmpty
+    )
+
+    // Save to persistent storage, send to server, etc.
+    save(logEntry)
+  }
+
+  private func save(_ entry: UserMessageLogEntry) {
+    // Implementation for saving log entries
+    // This could be CoreData, SQLite, or remote API
+  }
+}
+
+struct UserMessageLogEntry {
+  let timestamp: Date
+  let message: String
+  let codeSelectionCount: Int
+  let attachmentCount: Int
+  let hasCodeContext: Bool
+  let hasAttachments: Bool
+}
+
+// MARK: - Usage in Existing App
+
+struct ExistingAppWithLogging: App {
+  @StateObject private var analyticsManager = AnalyticsManager()
+
+  var body: some Scene {
+    WindowGroup {
+      ClaudeCodeContainer(
+        claudeCodeConfiguration: .default,
+        uiConfiguration: UIConfiguration(appName: "My App"),
+        onUserMessageSent: analyticsManager.handleUserMessage
+      )
+    }
+  }
+}
+
+class AnalyticsManager: ObservableObject {
+  func handleUserMessage(_ message: String, codeSelections: [TextSelection]?, attachments: [FileAttachment]?) {
+    // Your custom logging implementation
+    Task {
+      await logToServer(message: message, metadata: [
+        "has_context": codeSelections != nil,
+        "attachment_count": attachments?.count ?? 0
+      ])
+    }
+  }
+
+  private func logToServer(message: String, metadata: [String: Any]) async {
+    // Async logging to remote server
+  }
+}

--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -7,13 +7,15 @@ import SwiftUI
 public struct ClaudeCodeContainer: View {
   
   // MARK: Lifecycle
-  
+
   public init(
     claudeCodeConfiguration: ClaudeCodeConfiguration,
-    uiConfiguration: UIConfiguration)
+    uiConfiguration: UIConfiguration,
+    onUserMessageSent: ((String, [TextSelection]?, [FileAttachment]?) -> Void)? = nil)
   {
     self.claudeCodeConfiguration = claudeCodeConfiguration
     self.uiConfiguration = uiConfiguration
+    self.onUserMessageSent = onUserMessageSent
     customStorage = SimplifiedClaudeCodeSQLiteStorage()
     // SessionManager will be initialized in initializeClaudeCodeUI with proper globalPreferences
     sessionManager = SimplifiedSessionManager(
@@ -55,6 +57,7 @@ public struct ClaudeCodeContainer: View {
   let customStorage: SessionStorageProtocol
   let claudeCodeConfiguration: ClaudeCodeConfiguration
   let uiConfiguration: UIConfiguration
+  let onUserMessageSent: ((String, [TextSelection]?, [FileAttachment]?) -> Void)?
   
   // MARK: Private
   
@@ -113,6 +116,7 @@ public struct ClaudeCodeContainer: View {
           await loadAvailableSessions()
         }
       },
+      onUserMessageSent: onUserMessageSent
     )
     
     await MainActor.run {

--- a/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
@@ -39,6 +39,9 @@ public final class ChatViewModel {
   
   /// Optional callback invoked when session changes, used for external state synchronization
   private let onSessionChange: ((String) -> Void)?
+
+  /// Optional callback invoked when a user message is sent, used for external logging
+  private let onUserMessageSent: ((String, [TextSelection]?, [FileAttachment]?) -> Void)?
   
   /// Controls whether this view model should manage sessions (load, save, switch, etc.)
   /// Set to false when using ChatScreen directly without RootView to avoid unnecessary session operations
@@ -142,7 +145,8 @@ public final class ChatViewModel {
     globalPreferences: GlobalPreferencesStorage,
     customPermissionService: CustomPermissionService,
     shouldManageSessions: Bool = true,
-    onSessionChange: ((String) -> Void)? = nil)
+    onSessionChange: ((String) -> Void)? = nil,
+    onUserMessageSent: ((String, [TextSelection]?, [FileAttachment]?) -> Void)? = nil)
   {
     self.claudeClient = claudeClient
     self.sessionStorage = sessionStorage
@@ -151,6 +155,7 @@ public final class ChatViewModel {
     self.customPermissionService = customPermissionService
     self.shouldManageSessions = shouldManageSessions
     self.onSessionChange = onSessionChange
+    self.onUserMessageSent = onUserMessageSent
     self.sessionManager = SessionManager(sessionStorage: sessionStorage)
     self.streamProcessor = StreamProcessor(
       messageStore: messageStore,
@@ -239,7 +244,10 @@ public final class ChatViewModel {
     // Add user message with code selections and attachments for UI display
     let userMessage = MessageFactory.userMessage(content: displayContent, codeSelections: codeSelections, attachments: attachments)
     messageStore.addMessage(userMessage)
-    
+
+    // Invoke the callback for user message logging
+    onUserMessageSent?(displayContent, codeSelections, attachments)
+
     // Clear any previous errors
     error = nil
     


### PR DESCRIPTION
## Summary
- Adds optional `onUserMessageSent` callback to `ClaudeCodeContainer` 
- Enables consumers to log user message events for analytics, usage tracking, or debugging
- Non-breaking change with full backwards compatibility

## Changes
- **ClaudeCodeContainer**: Added optional callback parameter that gets passed to ChatViewModel
- **ChatViewModel**: Invokes callback when user sends a message, providing message text, code selections, and attachments
- **Examples**: Added comprehensive example showing various usage patterns

## Usage
```swift
ClaudeCodeContainer(
  claudeCodeConfiguration: config,
  uiConfiguration: uiConfiguration,
  onUserMessageSent: { message, codeSelections, attachments in
    // Log user message for analytics
    print("User sent: \(message)")
  }
)
```

## Test Plan
- [x] Build project successfully
- [x] Verify callback is optional (nil by default)
- [x] Test that callback fires only for user messages
- [ ] Manual testing with example implementation
- [ ] Verify no impact on existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)