### PR TITLE
feat: Improve chat input keyboard handling

### DIFF
--- a/Sources/ClaudeCodeCore/UI/ChatInputView.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatInputView.swift
@@ -52,7 +52,7 @@ struct ChatInputView: View {
     contextManager: ContextManager,
     xcodeObservationViewModel: XcodeObservationViewModel,
     permissionsService: PermissionsService,
-    placeholder: String = "Type a message...",
+    placeholder: String = "↵ send new message, ⇧↵ new line",
     triggerFocus: Binding<Bool> = .constant(false))
   {
     _text = text
@@ -345,8 +345,15 @@ extension ChatInputView {
       // Normal text editor behavior
       switch key.key {
       case .return:
-        sendMessage()
-        return .handled
+        // Check if shift is pressed - if so, allow new line
+        if key.modifiers.contains(.shift) {
+          // Return .ignored to let TextEditor handle the newline insertion naturally
+          return .ignored
+        } else {
+          // Send message on regular return (without shift)
+          sendMessage()
+          return .handled
+        }
       case .escape:
         if viewModel.isLoading {
           viewModel.cancelRequest()

--- a/Sources/ClaudeCodeCore/UI/ChatInputView.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatInputView.swift
@@ -350,6 +350,10 @@ extension ChatInputView {
           // Return .ignored to let TextEditor handle the newline insertion naturally
           return .ignored
         } else {
+          // Don't send message if already loading/streaming
+          if viewModel.isLoading {
+            return .handled  // Prevent any action including new line
+          }
           // Send message on regular return (without shift)
           sendMessage()
           return .handled

--- a/Sources/ClaudeCodeCore/UI/ChatScreen.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatScreen.swift
@@ -134,7 +134,6 @@ public struct ChatScreen: View {
         contextManager: contextManager,
         xcodeObservationViewModel: xcodeObservationViewModel,
         permissionsService: permissionsService,
-        placeholder: "Type a message...",
         triggerFocus: $triggerTextEditorFocus)
     }
     .overlay(approvalToastOverlay)


### PR DESCRIPTION
## Summary
- Added shift+return support for multi-line messages in the chat input
- Prevent message sending during AI streaming/loading with return key
- Updated placeholder text to show keyboard shortcuts with symbols

## Changes
1. **Multi-line support**: Users can now press Shift+Return to add a new line instead of sending the message
2. **Loading state protection**: Return key is disabled during streaming to prevent accidental message sending
3. **Improved placeholder**: Shows keyboard shortcuts (↵ send, ⇧↵ new line) to help users discover the functionality

## Test plan
- [x] Verify Shift+Return adds a new line
- [x] Verify Return sends message when not loading
- [x] Verify Return does nothing during streaming/loading
- [x] Verify placeholder shows keyboard shortcuts
- [x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)