### PR TITLE
feat: Add initialAdditionalSystemPromptPrefix support

### DIFF
--- a/Sources/ClaudeCodeCore/Models/ClaudeCodeAppConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/ClaudeCodeAppConfiguration.swift
@@ -53,14 +53,16 @@ public struct ClaudeCodeAppConfiguration {
   public init(
     appName: String,
     showSettingsInNavBar: Bool,
-    showRiskData: Bool = true
+    showRiskData: Bool = true,
+    initialAdditionalSystemPromptPrefix: String? = nil
   ) {
     self.init(
       claudeCodeConfiguration: .default,
       uiConfiguration: UIConfiguration(
         appName: appName,
         showSettingsInNavBar: showSettingsInNavBar,
-        showRiskData: showRiskData
+        showRiskData: showRiskData,
+        initialAdditionalSystemPromptPrefix: initialAdditionalSystemPromptPrefix
       )
     )
   }
@@ -83,7 +85,8 @@ public struct ClaudeCodeAppConfiguration {
     appName: String,
     workingDirectory: String? = nil,
     showSettingsInNavBar: Bool,
-    showRiskData: Bool = true
+    showRiskData: Bool = true,
+    initialAdditionalSystemPromptPrefix: String? = nil
   ) {
     var config = ClaudeCodeConfiguration.default
     config.workingDirectory = workingDirectory
@@ -92,7 +95,8 @@ public struct ClaudeCodeAppConfiguration {
       uiConfiguration: UIConfiguration(
         appName: appName,
         showSettingsInNavBar: showSettingsInNavBar,
-        showRiskData: showRiskData
+        showRiskData: showRiskData,
+        initialAdditionalSystemPromptPrefix: initialAdditionalSystemPromptPrefix
       )
     )
   }

--- a/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
@@ -11,21 +11,25 @@ import Foundation
 public struct UIConfiguration {
   /// The name of the application to display in the UI
   public let appName: String
-  
+
   /// Whether to show the settings button in the navigation bar
   public let showSettingsInNavBar: Bool
-  
+
   /// Whether to show risk-related data (risk labels and low-risk auto-approve option)
   public let showRiskData: Bool
-  
+
   /// Whether to show the token count in the loading indicator
   public let showTokenCount: Bool
-  
+
   /// Optional tooltip text to display when no working directory is selected
   public let workingDirectoryToolTip: String?
-  
+
   /// Whether to show the system prompt fields in settings
   public let showSystemPromptFields: Bool
+
+  /// Initial additional system prompt prefix that will be prepended to user's additional system prompt
+  /// This is not shown in the preferences UI and is set programmatically
+  public let initialAdditionalSystemPromptPrefix: String?
   
   /// Default configuration for ClaudeCodeUI app
   public static var `default`: UIConfiguration {
@@ -35,10 +39,11 @@ public struct UIConfiguration {
       showRiskData: true,
       showTokenCount: true,
       workingDirectoryToolTip: nil,
-      showSystemPromptFields: false
+      showSystemPromptFields: false,
+      initialAdditionalSystemPromptPrefix: nil
     )
   }
-  
+
   /// Library consumer configuration (without settings in nav bar)
   public static var library: UIConfiguration {
     UIConfiguration(
@@ -47,7 +52,8 @@ public struct UIConfiguration {
       showRiskData: true,
       showTokenCount: true,
       workingDirectoryToolTip: nil,
-      showSystemPromptFields: false
+      showSystemPromptFields: false,
+      initialAdditionalSystemPromptPrefix: nil
     )
   }
   
@@ -58,7 +64,8 @@ public struct UIConfiguration {
     showRiskData: Bool = true,
     showTokenCount: Bool = true,
     workingDirectoryToolTip: String? = nil,
-    showSystemPromptFields: Bool = false
+    showSystemPromptFields: Bool = false,
+    initialAdditionalSystemPromptPrefix: String? = nil
   ) {
     self.appName = appName
     self.showSettingsInNavBar = showSettingsInNavBar
@@ -66,5 +73,6 @@ public struct UIConfiguration {
     self.showTokenCount = showTokenCount
     self.workingDirectoryToolTip = workingDirectoryToolTip
     self.showSystemPromptFields = showSystemPromptFields
+    self.initialAdditionalSystemPromptPrefix = initialAdditionalSystemPromptPrefix
   }
 }

--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -63,9 +63,9 @@ public struct ClaudeCodeContainer: View {
   
   @State private var sessionManager: SimplifiedSessionManagerProtocol
   @State private var isInitialized = false
-  @State private var chatViewModel: ClaudeCodeCore.ChatViewModel?
+  @State private var chatViewModel: ChatViewModel?
   @State private var globalPreferences: GlobalPreferencesStorage?
-  @State private var claudeCodeDeps: ClaudeCodeCore.DependencyContainer?
+  @State private var claudeCodeDeps: DependencyContainer?
   
   @State private var showSessionPicker = false
   @State private var availableSessions: [StoredSession] = []
@@ -110,6 +110,7 @@ public struct ClaudeCodeContainer: View {
       settingsStorage: deps.settingsStorage,
       globalPreferences: globalPrefs,
       customPermissionService: deps.customPermissionService,
+      systemPromptPrefix: uiConfiguration.initialAdditionalSystemPromptPrefix,
       onSessionChange: { newSessionId in
         Task { @MainActor in
           currentSessionId = newSessionId


### PR DESCRIPTION
## Summary
- Adds support for programmatically setting an initial system prompt prefix
- The prefix is prepended to any user-defined additional system prompt
- Prefix is not visible in the preferences UI

## Changes
- Add `initialAdditionalSystemPromptPrefix` property to `UIConfiguration`
- Update `ClaudeCodeAppConfiguration` convenience initializers to support the new property
- Pass the prefix from `ClaudeCodeContainer` to `ChatViewModel`
- Implement concatenation logic in `ChatViewModel` that combines the prefix with user's additional prompt
- Add proper line break separation when both prefix and user prompt are present

## Usage Example
```swift
ClaudeCodeContainer(
  claudeCodeConfiguration: config,
  uiConfiguration: UIConfiguration(
    appName: "Claude Code UI",
    showSettingsInNavBar: true,
    showRiskData: false,
    initialAdditionalSystemPromptPrefix: "You are a specialized assistant."
  )
)
```

## Benefits
- Allows apps to inject their own system instructions
- Doesn't interfere with user preferences
- User's additional prompt is appended after the prefix
- Final prompt sent to Claude: `prefix + "\n" + userAppendSystemPrompt`

🤖 Generated with [Claude Code](https://claude.ai/code)