### PR TITLE
fix: Apply default working directory on app launch

### DIFF
--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -119,6 +119,13 @@ public struct ClaudeCodeContainer: View {
       },
       onUserMessageSent: onUserMessageSent
     )
+
+    // Set the default working directory from global preferences on app launch
+    if !globalPrefs.defaultWorkingDirectory.isEmpty {
+      claudeClient.configuration.workingDirectory = globalPrefs.defaultWorkingDirectory
+      viewModel.projectPath = globalPrefs.defaultWorkingDirectory
+      deps.settingsStorage.setProjectPath(globalPrefs.defaultWorkingDirectory)
+    }
     
     await MainActor.run {
       chatViewModel = viewModel


### PR DESCRIPTION
## Summary
- Fixed bug where the app wasn't reading the default working directory from preferences on launch
- Users can set a default working directory in preferences, but it wasn't being applied when the app started

## Changes
- Added code to `ClaudeCodeContainer.swift` to check for and apply the default working directory from global preferences during app initialization
- The fix applies the directory to the Claude client configuration, view model's project path, and settings storage

## Test Plan
- [x] Built and tested the application locally
- [ ] Set a default working directory in preferences
- [ ] Restart the app and verify the directory is automatically applied
- [ ] Verify sessions still work correctly with the default directory

🤖 Generated with [Claude Code](https://claude.ai/code)