### PR TITLE
Enhance Claude path resolution with manual override option

### DIFF
--- a/ClaudeCodeUI/App.swift
+++ b/ClaudeCodeUI/App.swift
@@ -13,19 +13,44 @@ import ClaudeCodeSDK
 struct ClaudeCodeUIAppWrapper: App {
 
   var config: ClaudeCodeConfiguration {
-    var config = ClaudeCodeConfiguration.default
+    // Start with the SDK's NVM-aware configuration
+    var config = ClaudeCodeConfiguration.withNvmSupport()
     config.enableDebugLogging = true
+
     let homeDir = NSHomeDirectory()
-    config.additionalPaths = [
-      "/usr/local/bin",
-      "/opt/homebrew/bin",
-      "/usr/bin",
-      "\(homeDir)/.claude/local",  // Claude standalone installation
-      "\(homeDir)/.nvm/versions/node/v22.16.0/bin",  // Common Node versions
-      "\(homeDir)/.nvm/current/bin",
-      "\(homeDir)/.nvm/versions/node/v20.11.1/bin",
-      "\(homeDir)/.nvm/versions/node/v18.19.0/bin"
-    ]
+
+    // PRIORITY 1: Check for local Claude installation (usually the newest version)
+    // This is typically installed via the Claude installer, not npm
+    let localClaudePath = "\(homeDir)/.claude/local"
+    if FileManager.default.fileExists(atPath: localClaudePath) {
+      // Insert at beginning for highest priority
+      config.additionalPaths.insert(localClaudePath, at: 0)
+    }
+
+    // PRIORITY 2: Check if user has manually specified Claude path (override everything)
+    let prefs = UserDefaults.standard
+    if let claudePath = prefs.string(forKey: "global.claudePath"),
+       !claudePath.isEmpty,
+       FileManager.default.fileExists(atPath: claudePath) {
+      let url = URL(fileURLWithPath: claudePath)
+      let directory = url.deletingLastPathComponent().path
+      // Insert at beginning for absolute highest priority
+      config.additionalPaths.insert(directory, at: 0)
+    }
+
+    // PRIORITY 3: Add essential system paths and common development tools
+    // The SDK uses /bin/zsh -l -c which loads the user's shell environment,
+    // so these are mainly fallbacks for tools installed in standard locations
+    config.additionalPaths.append(contentsOf: [
+      "/usr/local/bin",           // Homebrew on Intel Macs, common Unix tools
+      "/opt/homebrew/bin",        // Homebrew on Apple Silicon
+      "/usr/bin",                 // System binaries
+      "\(homeDir)/.bun/bin",      // Bun JavaScript runtime
+      "\(homeDir)/.deno/bin",     // Deno JavaScript runtime
+      "\(homeDir)/.cargo/bin",    // Rust cargo
+      "\(homeDir)/.local/bin"     // Python pip user installs
+    ])
+
     return config
   }
   var body: some Scene {

--- a/Sources/ClaudeCodeCore/Data/GlobalPreferencesStorage.swift
+++ b/Sources/ClaudeCodeCore/Data/GlobalPreferencesStorage.swift
@@ -23,6 +23,7 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
     static let mcpConfigPath = "global.mcpConfigPath"
     static let defaultWorkingDirectory = "global.defaultWorkingDirectory"
     static let claudeCommand = "global.claudeCommand"
+    static let claudePath = "global.claudePath"
 
     // Custom permission settings
     static let autoApproveLowRisk = "global.autoApproveLowRisk"
@@ -73,6 +74,12 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
   public var claudeCommand: String {
     didSet {
       userDefaults.set(claudeCommand, forKey: Keys.claudeCommand)
+    }
+  }
+
+  public var claudePath: String {
+    didSet {
+      userDefaults.set(claudePath, forKey: Keys.claudePath)
     }
   }
 
@@ -152,6 +159,9 @@ public final class GlobalPreferencesStorage: MCPConfigStorage {
 
     // Load Claude command or use default
     self.claudeCommand = userDefaults.string(forKey: Keys.claudeCommand) ?? "claude"
+
+    // Load Claude path or use empty string (optional field)
+    self.claudePath = userDefaults.string(forKey: Keys.claudePath) ?? ""
 
     // Load custom permission settings or use defaults
     self.autoApproveLowRisk = userDefaults.object(forKey: Keys.autoApproveLowRisk) as? Bool ?? false

--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -220,6 +220,7 @@ struct GlobalSettingsView: View {
     Section("ClaudeCode Configuration") {
       defaultWorkingDirectoryRow
       claudeCommandRow
+      claudePathRow
       maxTurnsRow
       if uiConfiguration.showSystemPromptFields {
         systemPromptRow
@@ -326,6 +327,37 @@ struct GlobalSettingsView: View {
       Text("The command to execute Claude Code (default: 'claude')")
         .font(.caption)
         .foregroundColor(.secondary)
+    }
+  }
+
+  @ViewBuilder
+  private var claudePathRow: some View {
+    @Bindable var preferences = globalPreferences
+    VStack(alignment: .leading, spacing: 8) {
+      Text("Claude Path (Advanced)")
+      HStack {
+        TextField("Path to Claude executable", text: $preferences.claudePath)
+          .textFieldStyle(.roundedBorder)
+          .font(.system(.body, design: .monospaced))
+
+        if !preferences.claudePath.isEmpty {
+          Button("Clear") {
+            preferences.claudePath = ""
+          }
+          .foregroundColor(.orange)
+        }
+      }
+      VStack(alignment: .leading, spacing: 4) {
+        Text("⚠️ Only use this if you see 'Claude not installed' errors")
+          .font(.caption)
+          .foregroundColor(.orange)
+        Text("Run 'which claude' in Terminal and paste the output here")
+          .font(.caption)
+          .foregroundColor(.secondary)
+        Text("Example: /Users/you/.nvm/versions/node/v22.16.0/bin/claude")
+          .font(.caption)
+          .foregroundColor(.secondary.opacity(0.7))
+      }
     }
   }
 

--- a/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
@@ -201,6 +201,20 @@ public final class ChatViewModel {
   /// Updates the Claude command when global preferences change
   public func updateClaudeCommand(from globalPreferences: GlobalPreferencesStorage) {
     claudeClient.configuration.command = globalPreferences.claudeCommand
+
+    // Add manual Claude path if specified
+    if !globalPreferences.claudePath.isEmpty {
+      // Validate that the file exists
+      if FileManager.default.fileExists(atPath: globalPreferences.claudePath) {
+        let url = URL(fileURLWithPath: globalPreferences.claudePath)
+        let directory = url.deletingLastPathComponent().path
+
+        // Insert at the beginning for highest priority (if not already present)
+        if !claudeClient.configuration.additionalPaths.contains(directory) {
+          claudeClient.configuration.additionalPaths.insert(directory, at: 0)
+        }
+      }
+    }
   }
   
   // MARK: - Public Methods


### PR DESCRIPTION
## Summary
- Adds intelligent Claude path resolution with priority-based discovery
- Implements manual path override option in Global Settings for troubleshooting
- Extends support for additional development tools (Bun, Deno, Cargo)

## Changes
- **App.swift**: Refactored configuration to use NVM-aware base config with priority-based path resolution
- **GlobalPreferencesStorage.swift**: Added `claudePath` property for manual override storage
- **GlobalSettingsView.swift**: Added UI field for manual Claude path configuration with helpful instructions
- **ChatViewModel.swift**: Integrated manual path validation and priority insertion

## Test Plan
- [ ] Test with default configuration (no manual path)
- [ ] Test manual path override with valid Claude installation
- [ ] Verify priority ordering (manual > local > NVM > system)
- [ ] Test with invalid manual path (should be ignored)
- [ ] Verify all existing Claude discovery methods still work

## Rationale
This enhancement addresses issues where users have Claude installed in non-standard locations or when automatic discovery fails. The priority system ensures:
1. Local installations (usually newest) take precedence
2. Manual overrides provide a failsafe option
3. System paths remain as fallbacks

🤖 Generated with [Claude Code](https://claude.ai/code)