### PR TITLE
Fix: Chat deletion improvements - confirmation dialog and default directory restoration

### DIFF
--- a/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
+++ b/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift
@@ -557,12 +557,21 @@ public final class ChatViewModel {
     // If deleting the current session, clear the chat interface and working directory
     if currentSessionId == id {
       clearConversation()
-      // Clear the working directory as well
-      settingsStorage.clearProjectPath()
-      claudeClient.configuration.workingDirectory = nil
-      projectPath = ""
+
+      // Apply default working directory if available
+      let defaultDirectory = globalPreferences.defaultWorkingDirectory
+      if !defaultDirectory.isEmpty {
+        claudeClient.configuration.workingDirectory = defaultDirectory
+        projectPath = defaultDirectory
+        settingsStorage.setProjectPath(defaultDirectory)
+      } else {
+        // Only clear if no default is set
+        settingsStorage.clearProjectPath()
+        claudeClient.configuration.workingDirectory = nil
+        projectPath = ""
+      }
     }
-    
+
     // Delete from storage
     await sessionManager.deleteSession(id: id)
   }


### PR DESCRIPTION
## Summary
- Added confirmation dialog when clicking trash button to prevent accidental deletions
- Implemented proper SQLite database cleanup when deleting sessions
- Restored default working directory after session deletion

## Problems Fixed

### 1. Missing Confirmation Dialog & Database Cleanup
**Problem:** The trash button in chat screen only cleared the UI without:
- Showing any confirmation (risk of accidental deletion)
- Removing the session from SQLite database

**Solution:** 
- Added confirmation alert before deletion
- Modified `clearChat` to properly call `deleteSession(id:)` for saved sessions
- Shows different messages for saved sessions vs temporary conversations

### 2. Default Working Directory Not Restored
**Problem:** After deleting a session, the app showed "no directory selected" alert even when a default working directory was configured in preferences

**Solution:**
- Updated `deleteSession` to check for and apply the default working directory from global preferences
- Ensures seamless continuation after session deletion

## Changes Made

### `/Sources/ClaudeCodeCore/UI/ChatScreen.swift`
- Added `@State private var showDeleteConfirmation`
- Modified trash button to show confirmation dialog
- Updated `clearChat()` to handle both saved sessions and temporary conversations
- Added `.alert()` modifier with appropriate messaging

### `/Sources/ClaudeCodeCore/ViewModels/ChatViewModel.swift`
- Modified `deleteSession()` to restore default working directory from global preferences
- Only clears working directory if no default is configured

## Test Plan
- [x] Build passes without errors
- [ ] Click trash with empty conversation - button should be disabled
- [ ] Click trash with unsaved messages - shows "clear conversation" confirmation
- [ ] Click trash with saved session - shows "delete session" confirmation  
- [ ] Cancel confirmation - nothing happens
- [ ] Confirm deletion with default directory set - can immediately send new message
- [ ] Confirm deletion without default directory - shows "no directory" alert as expected
- [ ] Session properly removed from database and session list

🤖 Generated with [Claude Code](https://claude.ai/code)