### PR TITLE
Fix: Multiple UI improvements - deletion dialog, default directory, and message truncation

### DIFF
--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/ClaudeCodeContainer.swift
@@ -234,7 +234,7 @@ public struct ClaudeCodeContainer: View {
       }
     } message: {
       if let session = sessionToDelete {
-        Text("Are you sure you want to delete the session \"\(session.firstUserMessage)\"? This action cannot be undone.")
+        Text("Are you sure you want to delete the session \"\(session.firstUserMessage.truncateIntelligently(to: 100))\"? This action cannot be undone.")
       }
     }
   }

--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/SessionRow.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/SessionRow.swift
@@ -22,7 +22,7 @@ struct SessionRow: View {
         HStack {
           VStack(alignment: .leading, spacing: 4) {
             HStack {
-              Text(session.firstUserMessage)
+              Text(session.firstUserMessage.truncateIntelligently(to: 100))
                 .font(.headline)
                 .foregroundColor(.primary)
                 .lineLimit(1)


### PR DESCRIPTION
## Summary
This PR includes three important fixes to improve the user experience:

1. **Chat deletion confirmation and database cleanup**
2. **Default working directory restoration after deletion**
3. **Message truncation in session alerts and lists**

## Changes

### 1. Chat Deletion Improvements (`ChatScreen.swift`)
**Problem:** 
- No confirmation dialog when deleting from chat screen (risk of accidental deletion)
- Sessions weren't removed from SQLite database, only cleared from UI

**Solution:**
- Added confirmation alert before deletion
- Properly calls `deleteSession(id:)` for saved sessions to clean up database
- Shows different messages for saved sessions vs temporary conversations

### 2. Default Working Directory Fix (`ChatViewModel.swift`)
**Problem:** After deleting a session, users got "no directory selected" alert even with a default working directory configured

**Solution:**
- Modified `deleteSession()` to restore the default working directory from global preferences
- Ensures seamless continuation after session deletion

### 3. Message Truncation (`ClaudeCodeContainer.swift`, `SessionRow.swift`)
**Problem:** Long first messages in sessions caused the deletion alert to extend too tall

**Solution:**
- Truncate messages to 100 characters in both the alert and session list
- Uses intelligent truncation that breaks at word boundaries
- Adds "..." suffix to indicate truncation

## Test Plan
- [x] Build passes without errors
- [ ] **Chat Deletion Tests:**
  - [ ] Trash button disabled when conversation is empty
  - [ ] Shows "clear conversation" confirmation for unsaved messages
  - [ ] Shows "delete session" confirmation for saved sessions
  - [ ] Cancel button works correctly
  - [ ] Deletion properly removes from database
- [ ] **Working Directory Tests:**
  - [ ] After deletion with default directory set - can immediately send new message
  - [ ] After deletion without default directory - shows "no directory" alert as expected
- [ ] **Message Truncation Tests:**
  - [ ] Long messages (>100 chars) show truncated in deletion alert
  - [ ] Long messages show truncated in session list
  - [ ] Short messages display normally without truncation

## Screenshots
The changes prevent UI issues like overly tall alerts and provide better user feedback for destructive actions.

🤖 Generated with [Claude Code](https://claude.ai/code)