### PR TITLE
Fix: Make Claude Path UI section dynamic based on configured command

### DIFF
--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -346,13 +346,13 @@ struct GlobalSettingsView: View {
         }
       }
       VStack(alignment: .leading, spacing: 4) {
-        Text("⚠️ Only use this if you see 'Claude not installed' errors")
+        Text("⚠️ Only use this if you see '\(preferences.claudeCommand.capitalized) not installed' errors")
           .font(.caption)
           .foregroundColor(.orange)
-        Text("Run 'which claude' in Terminal and paste the output here")
+        Text("Run 'which \(preferences.claudeCommand)' in Terminal and paste the output here")
           .font(.caption)
           .foregroundColor(.secondary)
-        Text("Example: /Users/you/.nvm/versions/node/v22.16.0/bin/claude")
+        Text("Example: /Users/you/.nvm/versions/node/v22.16.0/bin/\(preferences.claudeCommand)")
           .font(.caption)
           .foregroundColor(.secondary.opacity(0.7))
       }


### PR DESCRIPTION
## Summary
- Updates the Claude Path help text in GlobalSettingsView to dynamically use the configured command
- Previously hardcoded "which claude" now shows "which [command]" based on user configuration
- Example path now dynamically shows the actual configured command name

## Problem
When users configure a custom command (other than the default "claude"), the help text in the Claude Path section still showed hardcoded references to "claude", which was confusing and incorrect.

## Solution
Updated the help text to use `preferences.claudeCommand` to dynamically display:
- The correct error message (e.g., "MyCustomCommand not installed")
- The correct terminal command (e.g., "which myCustomCommand")
- The correct example path (e.g., "/Users/you/.../bin/myCustomCommand")

## Test plan
- [ ] Configure a custom command in settings (e.g., "mycommand")
- [ ] Open Global Settings > Preferences > Claude Path section
- [ ] Verify the help text shows "which mycommand" instead of "which claude"
- [ ] Verify the example path ends with the custom command name
- [ ] Verify the error message shows the custom command name

🤖 Generated with [Claude Code](https://claude.ai/code)