### PR TITLE
feat: Add comprehensive git worktree support

### DIFF
--- a/Sources/ClaudeCodeCore/UI/WelcomeRow.swift
+++ b/Sources/ClaudeCodeCore/UI/WelcomeRow.swift
@@ -155,7 +155,18 @@ private struct WorktreeListView: View {
       ForEach(worktrees, id: \.path) { worktree in
         WorktreeListItem(
           worktree: worktree,
-          isSelected: worktree.path == currentPath,
+          isSelected: {
+            let currentClean = currentPath.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            let worktreeClean = worktree.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+
+            // Exact match
+            if currentClean == worktreeClean {
+              return true
+            }
+
+            // Check if current is subdirectory (with separator to avoid prefix collision)
+            return currentClean.hasPrefix(worktreeClean + "/")
+          }(),
           onSelect: {
             onWorktreeSelected(worktree.path)
           }


### PR DESCRIPTION
## Summary
- Adds full git worktree detection and management capabilities to ClaudeCodeUI
- Enables users to switch between worktrees without starting new sessions
- Improves session tracking with branch and worktree information

## Key Features
### 🌳 Worktree Detection & Management
- Created `GitWorktreeDetector` utility for detecting and listing worktrees
- Detects whether a directory is a main repository or worktree
- Lists all available worktrees for a repository with branch information

### 💾 Session Storage Enhancement  
- Extended `StoredSession` model to track branch names and worktree status
- Added SQLite migration (v2) to support worktree fields
- Sessions now remember which branch/worktree they were created in

### 🎨 UI Improvements
- **WelcomeRow**: Added expandable worktree selector showing all available worktrees
- **SessionRow**: Shows branch/worktree information with appropriate icons
- Visual indicators: Blue for main branch, orange for worktrees
- Fixed worktree selection to properly handle subdirectories

### 🛡️ Safety & Reliability
- Added 3-second timeout protection for git commands to prevent hanging
- Path validation before switching to worktrees with user alerts
- Graceful degradation when worktree detection fails
- Automatic refresh of stale worktree entries

## Implementation Details
- Refactored WelcomeRow into smaller, focused components for maintainability
- Added comprehensive previews showing all UI states
- Fixed compilation errors and removed unnecessary project files
- Improved worktree selection logic to handle subdirectories correctly

## Testing
The implementation has been tested with:
- Multiple worktrees in the same repository
- Switching between worktrees and subdirectories
- Stale/deleted worktree handling
- SQL migration compatibility

## Screenshots
The UI now shows:
- Expandable worktree list in WelcomeRow
- Branch/worktree indicators in SessionRow  
- Clear selection state with blue background
- Proper handling of subdirectory navigation

🤖 Generated with [Claude Code](https://claude.ai/code)