### PR TITLE
Lock worktree switching when chat session has messages

### DIFF
--- a/Sources/ClaudeCodeCore/UI/ChatScreen+MessagesList.swift
+++ b/Sources/ClaudeCodeCore/UI/ChatScreen+MessagesList.swift
@@ -102,6 +102,7 @@ extension ChatScreen {
           showSettingsButton: shouldShowSettingsButton,
           appName: uiConfiguration.appName,
           toolTip: uiConfiguration.workingDirectoryToolTip,
+          hasMessages: !viewModel.messages.isEmpty,
           onSettingsTapped: {
             settingsTypeToShow = .session
             showingSettings = true

--- a/Sources/ClaudeCodeCore/UI/SimplifiedSession/SessionRow.swift
+++ b/Sources/ClaudeCodeCore/UI/SimplifiedSession/SessionRow.swift
@@ -46,6 +46,7 @@ struct SessionRow: View {
           Spacer()
         }
         .padding(10)
+        .contentShape(Rectangle())
       }
       .buttonStyle(.plain)
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -62,7 +63,6 @@ struct SessionRow: View {
       RoundedRectangle(cornerRadius: 6)
         .stroke(isCurrentSession ? Color.brandPrimary : Color.clear, lineWidth: isCurrentSession ? 1 : 0)
     )
-    .contentShape(Rectangle())
   }
   
   @Environment(\.colorScheme) private var colorScheme


### PR DESCRIPTION
## Summary
- Prevents users from switching worktrees after starting a chat session to avoid state conflicts
- Adds visual feedback and proper UX when worktree switching is locked
- Ensures session integrity by maintaining the same working directory throughout the conversation

## Changes
- Added `hasMessages` parameter to `WelcomeRow` to track if the session has any messages
- Disabled the pencil button (edit directory) when session has messages
- Prevented worktree list expansion when session is active  
- Shows selected worktree branch name instead of "X worktrees" count when locked
- Added visual feedback (reduced opacity) and updated tooltips for locked state

## Test Plan
- [ ] Start a new chat session without any messages
- [ ] Verify you can click the pencil button to change directories
- [ ] Verify you can expand/collapse the worktree list if multiple worktrees exist
- [ ] Send a message to start the chat session
- [ ] Verify the pencil button is now disabled with reduced opacity
- [ ] Verify the worktree button shows the selected branch name instead of count
- [ ] Verify clicking the worktree button no longer expands the list
- [ ] Verify tooltips indicate the locked state
- [ ] Start a new session to verify functionality resets

## Why This Change?
As discussed, allowing users to switch worktrees mid-session could lead to conflicting states where the Claude API is working with one directory while the UI shows another. This change prevents that confusion by locking the working directory once a conversation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)