### PR TITLE
Add showAdditionalSystemPromptField to UIConfiguration

### DIFF
--- a/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
@@ -27,6 +27,9 @@ public struct UIConfiguration {
   /// Whether to show the system prompt fields in settings
   public let showSystemPromptFields: Bool
 
+  /// Whether to show the additional system prompt field in settings
+  public let showAdditionalSystemPromptField: Bool
+
   /// Initial additional system prompt prefix that will be prepended to user's additional system prompt
   /// This is not shown in the preferences UI and is set programmatically
   public let initialAdditionalSystemPromptPrefix: String?
@@ -40,6 +43,7 @@ public struct UIConfiguration {
       showTokenCount: true,
       workingDirectoryToolTip: nil,
       showSystemPromptFields: false,
+      showAdditionalSystemPromptField: true,
       initialAdditionalSystemPromptPrefix: nil
     )
   }
@@ -53,6 +57,7 @@ public struct UIConfiguration {
       showTokenCount: true,
       workingDirectoryToolTip: nil,
       showSystemPromptFields: false,
+      showAdditionalSystemPromptField: true,
       initialAdditionalSystemPromptPrefix: nil
     )
   }
@@ -65,6 +70,7 @@ public struct UIConfiguration {
     showTokenCount: Bool = true,
     workingDirectoryToolTip: String? = nil,
     showSystemPromptFields: Bool = false,
+    showAdditionalSystemPromptField: Bool = true,
     initialAdditionalSystemPromptPrefix: String? = nil
   ) {
     self.appName = appName
@@ -73,6 +79,7 @@ public struct UIConfiguration {
     self.showTokenCount = showTokenCount
     self.workingDirectoryToolTip = workingDirectoryToolTip
     self.showSystemPromptFields = showSystemPromptFields
+    self.showAdditionalSystemPromptField = showAdditionalSystemPromptField
     self.initialAdditionalSystemPromptPrefix = initialAdditionalSystemPromptPrefix
   }
 }

--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -247,7 +247,9 @@ struct GlobalSettingsView: View {
       if uiConfiguration.showSystemPromptFields {
         systemPromptRow
       }
-      appendSystemPromptRow
+      if uiConfiguration.showAdditionalSystemPromptField {
+        appendSystemPromptRow
+      }
       allowedToolsRow
       mcpConfigurationRow
     }


### PR DESCRIPTION
## Summary
Adds `showAdditionalSystemPromptField` configuration option to control visibility of the "Append System Prompt" field in preferences.

## Changes
- Add `showAdditionalSystemPromptField: Bool` property to UIConfiguration
- Default to `true` to maintain current behavior (backwards compatible)
- Update GlobalSettingsView to conditionally show `appendSystemPromptRow` based on flag
- Follows same pattern as existing `showSystemPromptFields`

## Behavior
- **Default**: `showAdditionalSystemPromptField = true` → Field is shown (current behavior)
- **Hidden**: Library consumers can set `showAdditionalSystemPromptField: false` to hide the field

## Backwards Compatibility
- ✅ Fully backwards compatible
- All existing code continues to work without modifications
- Default value maintains current behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)