### PR TITLE
Add FigmaRemoteMcp and settings visibility flags

### DIFF
--- a/Sources/ClaudeCodeCore/Models/MCPConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/MCPConfiguration.swift
@@ -24,7 +24,7 @@ struct MCPConfiguration: Codable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let serverDict = try container.decode([String: MCPServerConfig.ServerData].self, forKey: .mcpServers)
-    
+
     // Convert ServerData to MCPServerConfig with names
     self.mcpServers = serverDict.reduce(into: [:]) { result, pair in
       result[pair.key] = MCPServerConfig(
@@ -32,24 +32,24 @@ struct MCPConfiguration: Codable {
         command: pair.value.command ?? "",
         args: pair.value.args ?? [],
         env: pair.value.env,
-        url: nil  // URL is not decoded from MCP config
+        url: pair.value.url
       )
     }
   }
-  
+
   func encode(to encoder: Encoder) throws {
     var container = encoder.container(keyedBy: CodingKeys.self)
-    
+
     // Convert MCPServerConfig to ServerData for encoding
     let serverDict = mcpServers.reduce(into: [String: MCPServerConfig.ServerData]()) { result, pair in
       result[pair.key] = MCPServerConfig.ServerData(
         command: pair.value.command.isEmpty ? nil : pair.value.command,
         args: pair.value.args.isEmpty ? nil : pair.value.args,
-        env: pair.value.env
-        // Note: url is not encoded as it's not a valid MCP field
+        env: pair.value.env,
+        url: pair.value.url
       )
     }
-    
+
     try container.encode(serverDict, forKey: .mcpServers)
   }
 }
@@ -75,7 +75,7 @@ struct MCPServerConfig: Identifiable {
     let command: String?
     let args: [String]?
     let env: [String: String]?
-    // Note: url is not included in encoding/decoding as it's not a valid MCP field
+    let url: String?
   }
 }
 
@@ -87,6 +87,10 @@ extension MCPServerConfig {
       name: "XcodeBuildMCP",
       command: "npx",
       args: ["-y", "xcodebuildmcp@latest"]
+    ),
+    MCPServerConfig(
+      name: "FigmaRemoteMcp",
+      url: "http://mcp.figma.com/mcp"
     )
   ]
 }

--- a/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
+++ b/Sources/ClaudeCodeCore/Models/UIConfiguration.swift
@@ -42,6 +42,12 @@ public struct UIConfiguration {
   /// This is not shown in the preferences UI and is set programmatically
   public let initialAdditionalSystemPromptPrefix: String?
 
+  /// Whether to show Xcode integration settings (Accessibility permission, keyboard shortcut)
+  public let showXcodeIntegrationSettings: Bool
+
+  /// Whether to show Claude command/path settings in preferences
+  public let showClaudeCommandSettings: Bool
+
   /// Default configuration for ClaudeCodeUI app
   public static var `default`: UIConfiguration {
     UIConfiguration(
@@ -54,7 +60,9 @@ public struct UIConfiguration {
       appIconAssetName: nil,
       showSystemPromptFields: false,
       showAdditionalSystemPromptField: true,
-      initialAdditionalSystemPromptPrefix: nil
+      initialAdditionalSystemPromptPrefix: nil,
+      showXcodeIntegrationSettings: true,
+      showClaudeCommandSettings: true
     )
   }
 
@@ -70,7 +78,9 @@ public struct UIConfiguration {
       appIconAssetName: nil,
       showSystemPromptFields: false,
       showAdditionalSystemPromptField: true,
-      initialAdditionalSystemPromptPrefix: nil
+      initialAdditionalSystemPromptPrefix: nil,
+      showXcodeIntegrationSettings: true,
+      showClaudeCommandSettings: true
     )
   }
 
@@ -85,7 +95,9 @@ public struct UIConfiguration {
     appIconAssetName: String? = nil,
     showSystemPromptFields: Bool = false,
     showAdditionalSystemPromptField: Bool = true,
-    initialAdditionalSystemPromptPrefix: String? = nil
+    initialAdditionalSystemPromptPrefix: String? = nil,
+    showXcodeIntegrationSettings: Bool = true,
+    showClaudeCommandSettings: Bool = true
   ) {
     self.appName = appName
     self.showSettingsInNavBar = showSettingsInNavBar
@@ -97,5 +109,7 @@ public struct UIConfiguration {
     self.showSystemPromptFields = showSystemPromptFields
     self.showAdditionalSystemPromptField = showAdditionalSystemPromptField
     self.initialAdditionalSystemPromptPrefix = initialAdditionalSystemPromptPrefix
+    self.showXcodeIntegrationSettings = showXcodeIntegrationSettings
+    self.showClaudeCommandSettings = showClaudeCommandSettings
   }
 }

--- a/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
+++ b/Sources/ClaudeCodeCore/UI/GlobalSettingsView.swift
@@ -214,7 +214,7 @@ struct GlobalSettingsView: View {
     @Bindable var preferences = globalPreferences
     return VStack(spacing: 0) {
       Form {
-        if xcodeObservationViewModel != nil && permissionsService != nil {
+        if uiConfiguration.showXcodeIntegrationSettings && xcodeObservationViewModel != nil && permissionsService != nil {
           xcodeIntegrationSection
         }
         claudeCodeConfigurationSection
@@ -242,8 +242,10 @@ struct GlobalSettingsView: View {
   private var claudeCodeConfigurationSection: some View {
     Section("ClaudeCode Configuration") {
       defaultWorkingDirectoryRow
-      claudeCommandRow
-      claudePathRow
+      if uiConfiguration.showClaudeCommandSettings {
+        claudeCommandRow
+        claudePathRow
+      }
       if uiConfiguration.showSystemPromptFields {
         systemPromptRow
       }


### PR DESCRIPTION
## Summary
- Add **FigmaRemoteMcp** to predefined MCP servers (URL-based SSE server at `http://mcp.figma.com/mcp`)
- Add URL support to MCP server encoding/decoding for SSE servers
- Add `showXcodeIntegrationSettings` flag to hide Accessibility permission and keyboard shortcut settings
- Add `showClaudeCommandSettings` flag to hide Claude Command and Claude Path settings

## Use Case
Enables a "light" demo mode for Claw by hiding advanced settings that aren't needed for demos.

## Test plan
- [ ] Verify FigmaRemoteMcp appears in Quick Add section
- [ ] Verify setting `showXcodeIntegrationSettings: false` hides the Xcode Integration section
- [ ] Verify setting `showClaudeCommandSettings: false` hides Claude Command and Path rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)